### PR TITLE
Force LC_MESSAGE to C for yum exec, fix addons install problems

### DIFF
--- a/additionals/usr/sbin/close-on-exec.pl
+++ b/additionals/usr/sbin/close-on-exec.pl
@@ -20,4 +20,4 @@ foreach $s (@l) {
 }
 POSIX::setsid();
 
-exec @ARGV;
+exec "LC_MESSAGES=C @ARGV";


### PR DESCRIPTION
CHANGED: /usr/sbin/close-on-exec.pl