### PR TITLE
ACL: lista opcional de extensiones a monitorear por usuario (acl_user.monitorexten)

### DIFF
--- a/framework/html/libs/paloSantoACL.class.php
+++ b/framework/html/libs/paloSantoACL.class.php
@@ -896,6 +896,61 @@ class paloACL {
     }
 
     /**
+     * Devuelve la lista de extensiones que un usuario puede monitorear en el
+     * módulo de grabaciones (monitoring). Se almacena en acl_user.monitorexten
+     * como una lista separada por comas. Si la columna no existe (instalación
+     * sin migrar) o está vacía, devuelve un arreglo vacío y el módulo cae al
+     * comportamiento clásico (sólo la extensión propia del usuario).
+     *
+     * @param string   $username  Username del usuario
+     *
+     * @return array   arreglo de extensiones (strings), posiblemente vacío
+     */
+    function getUserMonitorExtensions($username)
+    {
+        $this->errMsg = '';
+        $extens = array();
+        if (is_null($username) || $username === '') return $extens;
+        $result = $this->_DB->getFirstRowQuery(
+            'SELECT monitorexten FROM acl_user WHERE name = ?', FALSE, array($username));
+        if (!is_array($result) || count($result) <= 0) {
+            // La columna puede no existir en instalaciones que no migraron;
+            // se ignora silenciosamente para preservar el comportamiento clásico.
+            return $extens;
+        }
+        $raw = $result[0];
+        if (!is_null($raw) && trim($raw) != '') {
+            foreach (explode(',', $raw) as $e) {
+                $e = trim($e);
+                if ($e != '') $extens[] = $e;
+            }
+        }
+        return $extens;
+    }
+
+    /**
+     * Asigna la lista de extensiones a monitorear de un usuario existente.
+     *
+     * @param string   $username  Username del usuario
+     * @param string   $list      lista separada por comas (NULL/'' para limpiar)
+     *
+     * @return boolean  VERDADERO en éxito, FALSO en error
+     */
+    function setUserMonitorExtensions($username, $list)
+    {
+        $this->errMsg = '';
+        if (is_null($list) || trim($list) == '') $list = NULL;
+        $r = $this->_DB->genQuery(
+            'UPDATE acl_user SET monitorexten = ? WHERE name = ?',
+            array($list, $username));
+        if (!$r) {
+            $this->errMsg = $this->_DB->errMsg;
+            return FALSE;
+        }
+        return TRUE;
+    }
+
+    /**
      * Procedimiento para obtener el is del recurso dado su nombre.
      *
      * @param string   $resource_name  Nombre del recurso

--- a/framework/setup/db/install/acl/1_schema.sql
+++ b/framework/setup/db/install/acl/1_schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE acl_membership (
   id_group INTEGER   NOT NULL default '0'
 );
 INSERT INTO "acl_membership" VALUES(1,1,1);
-CREATE TABLE acl_user (id INTEGER PRIMARY KEY, name varchar(50), description varchar(180), md5_password varchar(50), extension varchar(20));
+CREATE TABLE acl_user (id INTEGER PRIMARY KEY, name varchar(50), description varchar(180), md5_password varchar(50), extension varchar(20), monitorexten varchar(255));
 INSERT INTO "acl_user" VALUES(1,'admin',NULL,'06a581ba2ad4fa0d11127e1a27dbfa1f',NULL);
 CREATE TABLE acl_user_permission (id INTEGER PRIMARY KEY, id_action int(11), id_user int(11), id_resource int(11));
 CREATE TABLE acl_resource (id INTEGER PRIMARY KEY, name varchar(50), description varchar(180));

--- a/issabel-framework.spec
+++ b/issabel-framework.spec
@@ -2,7 +2,7 @@
 Summary: Issabel is a Web based software to administrate a PBX based in open source programs, forked from Elastix
 Name:    issabel-framework
 Version: 5.0.0
-Release: 3
+Release: 4
 License: GPL
 Vendor: Issabel Foundation
 Group: Applications/System
@@ -423,3 +423,6 @@ rm -rf $RPM_BUILD_ROOT
 %exclude /var/www/html/themes/tenant
 
 %changelog
+* Tue Jun 30 2026 Trixocom <hectorquiroz@trixocom.com> - 5.0.0-4
+- ACL: optional per-user monitor extensions (acl_user.monitorexten)
+


### PR DESCRIPTION
¡Hola Nico! 👋 Soy Hector, de Trixocom.

Nos surgió la necesidad de que ciertos usuarios puedan ver, en el módulo de Grabaciones (`monitoring`), no solo su propia extensión ni todas, sino **un grupo de extensiones**. Esta es la primera mitad de la feature (lado `framework`); la segunda va en un PR a `pbx` que usa estos helpers.

### Qué agrega
- Columna opcional `acl_user.monitorexten` (lista de extensiones separada por comas) en el schema de instalación (`setup/db/install/acl/1_schema.sql`).
- `paloACL::getUserMonitorExtensions($username)` → devuelve un arreglo de extensiones (vacío si no hay).
- `paloACL::setUserMonitorExtensions($username, $list)`.

### Compatibilidad
100% hacia atrás. Si la columna está vacía —o no existe en instalaciones que no migraron— `getUserMonitorExtensions()` devuelve un arreglo vacío y todo sigue funcionando como antes (el consumidor cae a la extensión propia del usuario).

### Nota de migración
Para instalaciones existentes hace falta:
```sql
ALTER TABLE acl_user ADD COLUMN monitorexten varchar(255);
```
No agregué un archivo `update_sql` versionado porque no quise asumir el esquema de versionado de la rama 5.x. Decime cómo preferís encajar la migración y lo ajusto.

El bump de release (3→4) lo podés descartar si manejás los releases por tu lado.

PR companion (lo consume): **IssabelFoundation/pbx#64**

¡Un abrazo!
— Hector / Trixocom
